### PR TITLE
fix imports - for reverse function

### DIFF
--- a/django_nav/base.py
+++ b/django_nav/base.py
@@ -20,7 +20,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 class NavType(object):
     name = u'I Forgot to Name this'

--- a/django_nav/conditionals.py
+++ b/django_nav/conditionals.py
@@ -1,5 +1,5 @@
 def user_is_authenticated(context, *args, **kwargs):
-    return context['user'].is_authenticated()
+    return context['user'].is_authenticated
 
 def user_is_staff(context, *args, **kwargs):
     return context['user'].is_staff


### PR DESCRIPTION
django_nav - uses django.core.urlresolvers to access the reverse() function which has been moved in Django 2.*  to -->django.urls